### PR TITLE
Include *.rake in Ruby files

### DIFF
--- a/lib/rubocop/git/commit_file.rb
+++ b/lib/rubocop/git/commit_file.rb
@@ -29,7 +29,7 @@ class CommitFile
   end
 
   def ruby?
-    filename.match(/.*\.rb$/)
+    filename.match(/\.(rb|rake)$/)
   end
 
   def modified_lines


### PR DESCRIPTION
Updates `RuboCop::Git::CommitFile#ruby?` to treat files with `.rake` extension as Ruby.

Removes redundant `.*` prefix assertion in Ruby pattern.